### PR TITLE
Fix deprecated Laravel Helpers

### DIFF
--- a/src/MongodbDataTablesServiceProvider.php
+++ b/src/MongodbDataTablesServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Pimlie\DataTables;
 
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Str;
 use Yajra\DataTables\DataTables;
 
 class MongodbDataTablesServiceProvider extends ServiceProvider
@@ -28,7 +29,7 @@ class MongodbDataTablesServiceProvider extends ServiceProvider
         }
         
         foreach (static::$engines as $engine => $class) {
-            $engine = camel_case($engine);
+            $engine = Str::camel($engine);
 
             if (!DataTables::hasMacro($engine)) {
                 DataTables::macro($engine, function () use ($class) {


### PR DESCRIPTION
Fix #4 

Changed support for camel case from camel_case to Str::camel for Laravel 5.7+